### PR TITLE
(fix): Notice: Function _load_textdomain_just_in_time was called inco…

### DIFF
--- a/src/OpenConvenanten/Foundation/Plugin.php
+++ b/src/OpenConvenanten/Foundation/Plugin.php
@@ -36,7 +36,6 @@ class Plugin
     public function __construct(string $rootPath)
     {
         $this->rootPath = $rootPath;
-        load_plugin_textdomain($this->getName(), false, $this->getName() . '/languages/');
 
         $this->loader = new Loader;
 
@@ -86,6 +85,7 @@ class Plugin
 
         // Register the Hook loader.
         $this->loader->addAction('init', $this, 'filterPlugin', 4);
+		$this->loader->addAction('after_setup_theme', $this, 'loadTextDomain', 4);
         $this->loader->register();
 
         return true;
@@ -98,6 +98,14 @@ class Plugin
     {
         \do_action('yard/' . self::NAME . '/plugin', $this);
     }
+
+	/**
+	 * Load the plugin textdomain.
+	 */
+	public function loadTextDomain(): void
+	{
+		\load_plugin_textdomain($this->getName(), false, $this->getName() . '/languages/');
+	}
 
     /**
      * Call method on service providers.


### PR DESCRIPTION
…rrectly.

Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the openconvenanten domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later.